### PR TITLE
Fixed a infinite XP bug

### DIFF
--- a/src/main/java/net/nexia/xpshop/Commands/XPShopCommands.java
+++ b/src/main/java/net/nexia/xpshop/Commands/XPShopCommands.java
@@ -91,6 +91,10 @@ public class XPShopCommands extends BaseCommand
                     }
 
                     amountToBuy = Integer.parseInt(args[1]);
+                    if (amountToBuy <= 0) {
+                        player.sendMessage(Processes.color("&cAmount that can be bought must be more than 0"));
+                        return;
+                    }
                 }
                 catch (NumberFormatException e)
                 {


### PR DESCRIPTION
A bug was left in that allowed users to type

`/xpshop buy [item] -99`

and get infinite XP from it, because there was no check for numbers less than or equal to 0. I just added a check for that.